### PR TITLE
fixed inconsistent spacing

### DIFF
--- a/Adafruit_GPIO/I2C.py
+++ b/Adafruit_GPIO/I2C.py
@@ -52,8 +52,8 @@ def get_default_bus():
         # Beaglebone Black has multiple I2C buses, default to 1 (P9_19 and P9_20).
         return 1
     elif plat == Platform.UP:
-	# UP board uses I2C bus 1, like Revision 2 Pi
-	return 1
+        # UP board uses I2C bus 1, like Revision 2 Pi
+        return 1
     else:
         raise RuntimeError('Could not determine default I2C bus for platform.')
 


### PR DESCRIPTION
## Trigger
On Upboard with ubuntu 16:
```
$ python
Python 3.5.2 (default, Nov 12 2018, 13:43:14) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import Adafruit_GPIO.I2C as I2C
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/up/work/blind/Adafruit_Python_GPIO/Adafruit_GPIO/I2C.py", line 56
    return 1
           ^
```

## Changes 
replaced tabs with spaces


